### PR TITLE
Ensure AssertionFailedError is serializable

### DIFF
--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -16,6 +16,8 @@
 
 package org.opentest4j;
 
+import java.io.Serializable;
+
 /**
  * {@code AssertionFailedError} is an <em>initial draft</em> for a common
  * base class for test-related {@link AssertionError AssertionErrors}.
@@ -30,27 +32,29 @@ package org.opentest4j;
  */
 public class AssertionFailedError extends AssertionError {
 
-	private static final long serialVersionUID = 3170879295749989795L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * <em>Undefined</em> object, used to differentiate between a {@code null}
 	 * default value and a user-supplied {@code null} value.
 	 */
-	private static final Object UNDEFINED = new Object();
+	private static final Serializable UNDEFINED = new Serializable() {
+		private static final long serialVersionUID = 1L;
+	};
 
-	private final Object expected;
+	private final Serializable expected;
 
-	private final Object actual;
+	private final Serializable actual;
 
 	public AssertionFailedError() {
-		this((String) null);
+		this(null);
 	}
 
 	public AssertionFailedError(String message) {
 		this(message, UNDEFINED, UNDEFINED);
 	}
 
-	public AssertionFailedError(String message, Object expected, Object actual) {
+	public AssertionFailedError(String message, Serializable expected, Serializable actual) {
 		this(message, expected, actual, null);
 	}
 
@@ -58,7 +62,7 @@ public class AssertionFailedError extends AssertionError {
 		this(message, UNDEFINED, UNDEFINED, cause);
 	}
 
-	public AssertionFailedError(String message, Object expected, Object actual, Throwable cause) {
+	public AssertionFailedError(String message, Serializable expected, Serializable actual, Throwable cause) {
 		super((message == null || message.trim().length() == 0) ? "" : message);
 		initCause(cause);
 		this.expected = expected;
@@ -73,11 +77,11 @@ public class AssertionFailedError extends AssertionError {
 		return (this.actual != UNDEFINED);
 	}
 
-	public Object getExpected() {
+	public Serializable getExpected() {
 		return (this.expected == UNDEFINED ? null : this.expected);
 	}
 
-	public Object getActual() {
+	public Serializable getActual() {
 		return (this.actual == UNDEFINED ? null : this.actual);
 	}
 

--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -34,16 +34,7 @@ public class AssertionFailedError extends AssertionError {
 
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * <em>Undefined</em> object, used to differentiate between a {@code null}
-	 * default value and a user-supplied {@code null} value.
-	 */
-	private static final Serializable UNDEFINED = new Serializable() {
-		private static final long serialVersionUID = 1L;
-	};
-
 	private final Serializable expected;
-
 	private final Serializable actual;
 
 	public AssertionFailedError() {
@@ -51,7 +42,7 @@ public class AssertionFailedError extends AssertionError {
 	}
 
 	public AssertionFailedError(String message) {
-		this(message, UNDEFINED, UNDEFINED);
+		this(message, Undefined.INSTANCE, Undefined.INSTANCE);
 	}
 
 	public AssertionFailedError(String message, Serializable expected, Serializable actual) {
@@ -59,7 +50,7 @@ public class AssertionFailedError extends AssertionError {
 	}
 
 	public AssertionFailedError(String message, Throwable cause) {
-		this(message, UNDEFINED, UNDEFINED, cause);
+		this(message, Undefined.INSTANCE, Undefined.INSTANCE, cause);
 	}
 
 	public AssertionFailedError(String message, Serializable expected, Serializable actual, Throwable cause) {
@@ -70,19 +61,45 @@ public class AssertionFailedError extends AssertionError {
 	}
 
 	public boolean isExpectedDefined() {
-		return (this.expected != UNDEFINED);
+		return isDefined(this.expected);
 	}
 
 	public boolean isActualDefined() {
-		return (this.actual != UNDEFINED);
+		return isDefined(this.actual);
 	}
 
 	public Serializable getExpected() {
-		return (this.expected == UNDEFINED ? null : this.expected);
+		return (isExpectedDefined() ? this.expected : null);
 	}
 
 	public Serializable getActual() {
-		return (this.actual == UNDEFINED ? null : this.actual);
+		return (isActualDefined() ? this.actual : null);
 	}
 
+	private boolean isDefined(Serializable actual) {
+		return !Undefined.INSTANCE.equals(actual);
+	}
+
+	/**
+	 * <em>Undefined</em> object, used to differentiate between a {@code null}
+	 * default value and a user-supplied {@code null} value.
+	 */
+	private static class Undefined implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+		private static final Undefined INSTANCE = new Undefined();
+
+		private Undefined() {
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj != null && this.getClass().equals(obj.getClass());
+		}
+
+		@Override
+		public int hashCode() {
+			return 42;
+		}
+	}
 }

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -21,6 +21,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.junit.Test;
 
 /**
@@ -65,6 +70,48 @@ public class AssertionFailedErrorTests {
 		assertNull(errorWithoutExpectedAndActual.getExpected());
 		assertFalse(errorWithoutExpectedAndActual.isActualDefined());
 		assertNull(errorWithoutExpectedAndActual.getActual());
+	}
+
+	@Test
+	public void serializationWorksForAssertionFailedErrorWithMessageAndExpectedAndActualValues() throws Exception {
+		AssertionFailedError error = serializeAndDeserialize(new AssertionFailedError("a message", "foo", "bar"));
+
+		assertEquals("a message", error.getMessage());
+		assertTrue(error.isExpectedDefined());
+		assertEquals("foo", error.getExpected());
+		assertTrue(error.isActualDefined());
+		assertEquals("bar", error.getActual());
+	}
+
+	@Test
+	public void serializationWorksForAssertionFailedErrorWithoutAnyValues() throws Exception {
+		AssertionFailedError error = serializeAndDeserialize(new AssertionFailedError());
+
+		assertEquals("", error.getMessage());
+		assertFalse(error.isExpectedDefined());
+		assertNull(error.getExpected());
+		assertFalse(error.isActualDefined());
+		assertNull(error.getActual());
+	}
+
+	private AssertionFailedError serializeAndDeserialize(AssertionFailedError originalError) throws Exception {
+		byte[] bytes = serialize(originalError);
+		Object deserializedObject = deserialize(bytes);
+		assertEquals(AssertionFailedError.class, deserializedObject.getClass());
+		return (AssertionFailedError) deserializedObject;
+	}
+
+	private Object deserialize(byte[] bytes) throws Exception {
+		ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+		return in.readObject();
+	}
+
+	private byte[] serialize(Object object) throws Exception {
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(byteArrayOutputStream);
+		out.writeObject(object);
+		out.flush();
+		return byteArrayOutputStream.toByteArray();
 	}
 
 }

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -17,6 +17,9 @@
 package org.opentest4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -44,6 +47,24 @@ public class AssertionFailedErrorTests {
 		assertEquals("", new AssertionFailedError("   ", null).getMessage());
 		assertEquals("", new AssertionFailedError("   ", "foo", "bar").getMessage());
 		assertEquals("", new AssertionFailedError("   ", "foo", "bar", null).getMessage());
+	}
+
+	@Test
+	public void expectedAndActualValuesAreStored() {
+		AssertionFailedError errorWithExpectedAndActual = new AssertionFailedError(null, "foo", "bar");
+		assertTrue(errorWithExpectedAndActual.isExpectedDefined());
+		assertEquals("foo", errorWithExpectedAndActual.getExpected());
+		assertTrue(errorWithExpectedAndActual.isActualDefined());
+		assertEquals("bar", errorWithExpectedAndActual.getActual());
+	}
+
+	@Test
+	public void returnsNullForExpectedAndActualWhenNotPassedToConstructor() {
+		AssertionFailedError errorWithoutExpectedAndActual = new AssertionFailedError();
+		assertFalse(errorWithoutExpectedAndActual.isExpectedDefined());
+		assertNull(errorWithoutExpectedAndActual.getExpected());
+		assertFalse(errorWithoutExpectedAndActual.isActualDefined());
+		assertNull(errorWithoutExpectedAndActual.getActual());
 	}
 
 }


### PR DESCRIPTION
This pull request addresses #2 and fixes a problem with de-/serialization of `AssertionFailedErrors` with undefined values.