### PR TITLE
Introduce ValueWrapper

### DIFF
--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -16,8 +16,6 @@
 
 package org.opentest4j;
 
-import java.io.Serializable;
-
 /**
  * {@code AssertionFailedError} is an <em>initial draft</em> for a common
  * base class for test-related {@link AssertionError AssertionErrors}.
@@ -34,26 +32,30 @@ public class AssertionFailedError extends AssertionError {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Serializable expected;
-	private final Serializable actual;
+	private final ValueWrapper expected;
+	private final ValueWrapper actual;
 
 	public AssertionFailedError() {
 		this(null);
 	}
 
 	public AssertionFailedError(String message) {
-		this(message, Undefined.INSTANCE, Undefined.INSTANCE);
+		this(message, null);
 	}
 
-	public AssertionFailedError(String message, Serializable expected, Serializable actual) {
+	public AssertionFailedError(String message, Object expected, Object actual) {
 		this(message, expected, actual, null);
 	}
 
 	public AssertionFailedError(String message, Throwable cause) {
-		this(message, Undefined.INSTANCE, Undefined.INSTANCE, cause);
+		this(message, (ValueWrapper) null, (ValueWrapper) null, cause);
 	}
 
-	public AssertionFailedError(String message, Serializable expected, Serializable actual, Throwable cause) {
+	public AssertionFailedError(String message, Object expected, Object actual, Throwable cause) {
+		this(message, new ValueWrapper(expected), new ValueWrapper(actual), cause);
+	}
+
+	private AssertionFailedError(String message, ValueWrapper expected, ValueWrapper actual, Throwable cause) {
 		super((message == null || message.trim().length() == 0) ? "" : message);
 		initCause(cause);
 		this.expected = expected;
@@ -61,45 +63,19 @@ public class AssertionFailedError extends AssertionError {
 	}
 
 	public boolean isExpectedDefined() {
-		return isDefined(this.expected);
+		return this.expected != null;
 	}
 
 	public boolean isActualDefined() {
-		return isDefined(this.actual);
+		return this.actual != null;
 	}
 
-	public Serializable getExpected() {
-		return (isExpectedDefined() ? this.expected : null);
+	public ValueWrapper getExpected() {
+		return this.expected;
 	}
 
-	public Serializable getActual() {
-		return (isActualDefined() ? this.actual : null);
+	public ValueWrapper getActual() {
+		return this.actual;
 	}
 
-	private boolean isDefined(Serializable actual) {
-		return !Undefined.INSTANCE.equals(actual);
-	}
-
-	/**
-	 * <em>Undefined</em> object, used to differentiate between a {@code null}
-	 * default value and a user-supplied {@code null} value.
-	 */
-	private static class Undefined implements Serializable {
-
-		private static final long serialVersionUID = 1L;
-		private static final Undefined INSTANCE = new Undefined();
-
-		private Undefined() {
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj != null && this.getClass().equals(obj.getClass());
-		}
-
-		@Override
-		public int hashCode() {
-			return 42;
-		}
-	}
 }

--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -20,6 +20,9 @@ package org.opentest4j;
  * {@code AssertionFailedError} is an <em>initial draft</em> for a common
  * base class for test-related {@link AssertionError AssertionErrors}.
  *
+ * <p>In addition to a message and a cause this class stores the expected
+ * and actual values of an assertion using the {@link ValueWrapper} type.
+ *
  * <p><strong>WARNING</strong>: this is a <em>work in progress</em> and
  * is therefore guaranteed to undergo heavy revisions in the near future
  * based on community feedback.
@@ -35,22 +38,42 @@ public class AssertionFailedError extends AssertionError {
 	private final ValueWrapper expected;
 	private final ValueWrapper actual;
 
+	/**
+	 * Constructs an {@code AssertionFailedError} with no message, no cause
+	 * and no expected/actual values.
+	 */
 	public AssertionFailedError() {
 		this(null);
 	}
 
+	/**
+	 * Constructs an {@code AssertionFailedError} with a message, no cause
+	 * and no expected/actual values.
+	 */
 	public AssertionFailedError(String message) {
 		this(message, null);
 	}
 
+	/**
+	 * Constructs an {@code AssertionFailedError} with a message and
+	 * expected/actual values but without a cause.
+	 */
 	public AssertionFailedError(String message, Object expected, Object actual) {
 		this(message, expected, actual, null);
 	}
 
+	/**
+	 * Constructs an {@code AssertionFailedError} with a message and a cause
+	 * but without expected/actual values.
+	 */
 	public AssertionFailedError(String message, Throwable cause) {
 		this(message, null, null, cause);
 	}
 
+	/**
+	 * Constructs an {@code AssertionFailedError} with a message,
+	 * expected/actual values and a cause.
+	 */
 	public AssertionFailedError(String message, Object expected, Object actual, Throwable cause) {
 		this(message, new ValueWrapper(expected), new ValueWrapper(actual), cause);
 	}
@@ -62,18 +85,32 @@ public class AssertionFailedError extends AssertionError {
 		this.actual = actual;
 	}
 
+	/**
+	 * Returns {@code true} if the expected value is defined, i.e. was passed
+	 * to the constructor.
+	 */
 	public boolean isExpectedDefined() {
 		return this.expected != null;
 	}
 
+	/**
+	 * Returns {@code true} if the actual value is defined, i.e. was passed
+	 * to the constructor.
+	 */
 	public boolean isActualDefined() {
 		return this.actual != null;
 	}
 
+	/**
+	 * Returns the expected value if it is defined; otherwise {@code null}.
+	 */
 	public ValueWrapper getExpected() {
 		return this.expected;
 	}
 
+	/**
+	 * Returns the actual value if it is defined; otherwise {@code null}.
+	 */
 	public ValueWrapper getActual() {
 		return this.actual;
 	}

--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -48,7 +48,7 @@ public class AssertionFailedError extends AssertionError {
 	}
 
 	public AssertionFailedError(String message, Throwable cause) {
-		this(message, (ValueWrapper) null, (ValueWrapper) null, cause);
+		this(message, null, null, cause);
 	}
 
 	public AssertionFailedError(String message, Object expected, Object actual, Throwable cause) {

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j;
+
+import java.io.Serializable;
+
+public final class ValueWrapper implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Class<?> type;
+	private final Serializable value;
+	private final String stringRepresentation;
+	private final int identityHashCode;
+
+	public ValueWrapper(Object value) {
+		this.value = value instanceof Serializable ? (Serializable) value : null;
+		this.type = value != null ? value.getClass() : null;
+		this.stringRepresentation = String.valueOf(value);
+		this.identityHashCode = System.identityHashCode(value);
+	}
+
+	public Class<?> getType() {
+		return type;
+	}
+
+	public Serializable getValue() {
+		return value;
+	}
+
+	public String getStringRepresentation() {
+		return stringRepresentation;
+	}
+
+	public int getIdentityHashCode() {
+		return identityHashCode;
+	}
+
+	@Override
+	public String toString() {
+		if (type == null) {
+			return "null";
+		}
+		return stringRepresentation + " (" + type.getName() + "@" + Integer.toHexString(identityHashCode) + ")";
+	}
+}

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
  * Serializable representation of a value that was used in an assertion.
  *
  * <p>This class only stores the value if it implements {@link Serializable}.
- * In any case, it stores its type, its identity hash code and its string
+ * In any case, it stores its runtime type, identity hash code and string
  * representation, i.e. the result of invoking {@link Object#toString}.
  *
  * <p>The {@link #toString} method returns the string representation of the
@@ -51,7 +51,7 @@ public final class ValueWrapper implements Serializable {
 	}
 
 	/**
-	 * Returns the value's runtime class in case it wasn't {@code null};
+	 * Returns the value's runtime type in case it wasn't {@code null};
 	 * otherwise, {@code null}.
 	 */
 	public Class<?> getType() {
@@ -69,7 +69,7 @@ public final class ValueWrapper implements Serializable {
 	/**
 	 * Returns the value's string representation, i.e. the result of invoking
 	 * {@link Object#toString} at the time this object's constructor was
-	 * called. Returns {@code "null"} when the value was {@code null}.
+	 * called. Returns {@code "null"} if the value was {@code null}.
 	 */
 	public String getStringRepresentation() {
 		return stringRepresentation;
@@ -78,7 +78,7 @@ public final class ValueWrapper implements Serializable {
 	/**
 	 * Returns the value's identity hash code, i.e. the result of invoking
 	 * {@link System#identityHashCode} at the time this object's constructor
-	 * was called. Returns {@code 0} when the value was {@code null}.
+	 * was called. Returns {@code 0} if the value was {@code null}.
 	 */
 	public int getIdentityHashCode() {
 		return identityHashCode;

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -18,6 +18,18 @@ package org.opentest4j;
 
 import java.io.Serializable;
 
+/**
+ * Serializable representation of a value that was used in an assertion.
+ *
+ * <p>This class only stores the value if it implements {@link Serializable}.
+ * In any case, it stores its type, its identity hash code and its string
+ * representation, i.e. the result of invoking {@link Object#toString}.
+ *
+ * <p>The {@link #toString} method returns the string representation of the
+ * value along with its type and identity hash code.
+ *
+ * @see System#identityHashCode
+ */
 public final class ValueWrapper implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -27,6 +39,10 @@ public final class ValueWrapper implements Serializable {
 	private final String stringRepresentation;
 	private final int identityHashCode;
 
+	/**
+	 * Reads and stores the value's runtime type, string representation and
+	 * identity hash code.
+	 */
 	public ValueWrapper(Object value) {
 		this.value = value instanceof Serializable ? (Serializable) value : null;
 		this.type = value != null ? value.getClass() : null;
@@ -34,22 +50,44 @@ public final class ValueWrapper implements Serializable {
 		this.identityHashCode = System.identityHashCode(value);
 	}
 
+	/**
+	 * Returns the value's runtime class in case it wasn't {@code null};
+	 * otherwise, {@code null}.
+	 */
 	public Class<?> getType() {
 		return type;
 	}
 
+	/**
+	 * Returns the value as passed to the constructor in case it implemented
+	 * {@link Serializable}; otherwise, {@code null}.
+	 */
 	public Serializable getValue() {
 		return value;
 	}
 
+	/**
+	 * Returns the value's string representation, i.e. the result of invoking
+	 * {@link Object#toString} at the time this object's constructor was
+	 * called. Returns {@code "null"} when the value was {@code null}.
+	 */
 	public String getStringRepresentation() {
 		return stringRepresentation;
 	}
 
+	/**
+	 * Returns the value's identity hash code, i.e. the result of invoking
+	 * {@link System#identityHashCode} at the time this object's constructor
+	 * was called. Returns {@code 0} when the value was {@code null}.
+	 */
 	public int getIdentityHashCode() {
 		return identityHashCode;
 	}
 
+	/**
+	 * Returns the value's string representation along with its type and
+	 * identity hash code.
+	 */
 	@Override
 	public String toString() {
 		if (type == null) {

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -55,6 +55,18 @@ public class AssertionFailedErrorTests {
 	}
 
 	@Test
+	public void messageAndCauseAreStored() {
+		RuntimeException cause = new RuntimeException("cause");
+
+		AssertionFailedError error = new AssertionFailedError("my message", cause);
+
+		assertEquals("my message", error.getMessage());
+		assertEquals(cause, error.getCause());
+		assertFalse(error.isExpectedDefined());
+		assertFalse(error.isActualDefined());
+	}
+
+	@Test
 	public void expectedAndActualValuesAreStored() {
 		AssertionFailedError errorWithExpectedAndActual = new AssertionFailedError(null, "foo", "bar");
 		assertTrue(errorWithExpectedAndActual.isExpectedDefined());

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -58,9 +58,9 @@ public class AssertionFailedErrorTests {
 	public void expectedAndActualValuesAreStored() {
 		AssertionFailedError errorWithExpectedAndActual = new AssertionFailedError(null, "foo", "bar");
 		assertTrue(errorWithExpectedAndActual.isExpectedDefined());
-		assertEquals("foo", errorWithExpectedAndActual.getExpected());
+		assertEquals("foo", errorWithExpectedAndActual.getExpected().getValue());
 		assertTrue(errorWithExpectedAndActual.isActualDefined());
-		assertEquals("bar", errorWithExpectedAndActual.getActual());
+		assertEquals("bar", errorWithExpectedAndActual.getActual().getValue());
 	}
 
 	@Test
@@ -78,9 +78,9 @@ public class AssertionFailedErrorTests {
 
 		assertEquals("a message", error.getMessage());
 		assertTrue(error.isExpectedDefined());
-		assertEquals("foo", error.getExpected());
+		assertEquals("foo", error.getExpected().getValue());
 		assertTrue(error.isActualDefined());
-		assertEquals("bar", error.getActual());
+		assertEquals("bar", error.getActual().getValue());
 	}
 
 	@Test

--- a/src/test/java/org/opentest4j/ValueWrapperTests.java
+++ b/src/test/java/org/opentest4j/ValueWrapperTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opentest4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ValueWrapperTests {
+
+	@Test
+	public void wrapsNull() {
+		ValueWrapper wrapper = new ValueWrapper(null);
+
+		assertNull(wrapper.getType());
+		assertNull(wrapper.getValue());
+		assertEquals("null", wrapper.getStringRepresentation());
+		assertEquals(0, wrapper.getIdentityHashCode());
+		assertEquals("null", wrapper.toString());
+	}
+
+	@Test
+	public void wrapsSerializableValue() {
+		ValueWrapper wrapper = new ValueWrapper(1.2d);
+
+		assertEquals(Double.class, wrapper.getType());
+		assertEquals(1.2d, wrapper.getValue());
+		assertEquals("1.2", wrapper.getStringRepresentation());
+		assertNotEquals(0, wrapper.getIdentityHashCode());
+		assertTrue(wrapper.toString().startsWith("1.2 (java.lang.Double@"));
+		assertTrue(wrapper.toString().endsWith(")"));
+	}
+
+	@Test
+	public void wrapsNonSerializableValue() {
+		class NonSerializable {
+			@Override
+			public String toString() {
+				return "someString";
+			}
+		}
+		NonSerializable value = new NonSerializable();
+
+		ValueWrapper wrapper = new ValueWrapper(value);
+
+		assertEquals(NonSerializable.class, wrapper.getType());
+		assertNull(wrapper.getValue());
+		assertEquals("someString", wrapper.getStringRepresentation());
+		assertNotEquals(0, wrapper.getIdentityHashCode());
+
+		String toString = wrapper.toString();
+		assertTrue(toString, toString.startsWith("someString (" + NonSerializable.class.getName() + "@"));
+		assertTrue(toString, toString.endsWith(")"));
+	}
+}


### PR DESCRIPTION
- Stores original value in case it implements Serializable
- Stores type, string representation and identity hash code
- Useful toString() implementation

If we decide to merge this pull request I will add Javadoc to `AssertionFailedError` and `ValueWrapper`.