### PR TITLE
AssertionFailedError: Enable Java-behavior for late cause initialisation

### DIFF
--- a/src/main/java/org/opentest4j/AssertionFailedError.java
+++ b/src/main/java/org/opentest4j/AssertionFailedError.java
@@ -35,6 +35,8 @@ public class AssertionFailedError extends AssertionError {
 
 	private static final long serialVersionUID = 1L;
 
+	private static final Throwable NO_CAUSE = new RuntimeException("no cause indicator");
+
 	private final ValueWrapper expected;
 	private final ValueWrapper actual;
 
@@ -51,7 +53,7 @@ public class AssertionFailedError extends AssertionError {
 	 * and no expected/actual values.
 	 */
 	public AssertionFailedError(String message) {
-		this(message, null);
+		this(message, NO_CAUSE);
 	}
 
 	/**
@@ -59,7 +61,7 @@ public class AssertionFailedError extends AssertionError {
 	 * expected/actual values but without a cause.
 	 */
 	public AssertionFailedError(String message, Object expected, Object actual) {
-		this(message, expected, actual, null);
+		this(message, expected, actual, NO_CAUSE);
 	}
 
 	/**
@@ -80,7 +82,9 @@ public class AssertionFailedError extends AssertionError {
 
 	private AssertionFailedError(String message, ValueWrapper expected, ValueWrapper actual, Throwable cause) {
 		super((message == null || message.trim().length() == 0) ? "" : message);
-		initCause(cause);
+		if (cause != NO_CAUSE) {
+			initCause(cause);
+		}
 		this.expected = expected;
 		this.actual = actual;
 	}

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -26,7 +26,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Unit tests for {@link AssertionFailedError}.
@@ -36,6 +38,33 @@ import org.junit.Test;
  * @since 1.0
  */
 public class AssertionFailedErrorTests {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void undefinedCauseDoesNotInitializeCause() throws Exception {
+		RuntimeException lateCause = new RuntimeException("lateCause");
+		new AssertionFailedError().initCause(lateCause);
+		new AssertionFailedError("my message").initCause(lateCause);
+		new AssertionFailedError(null, "foo", "bar").initCause(lateCause);
+	}
+
+	@Test
+	public void cannotReinitializeNullCauseForMessageCauseArgs() throws Exception {
+		RuntimeException lazyCause = new RuntimeException("cause");
+
+		expectedException.expect(IllegalStateException.class);
+		new AssertionFailedError(null, null).initCause(lazyCause);
+	}
+
+	@Test
+	public void cannotReinitializeNullCauseForExpectedActualCauseArgs() throws Exception {
+		RuntimeException lazyCause = new RuntimeException("cause");
+
+		expectedException.expect(IllegalStateException.class);
+		new AssertionFailedError(null, "foo", "bar", null).initCause(lazyCause);
+	}
 
 	@Test
 	public void nullMessageIsConvertedToEmptyString() {


### PR DESCRIPTION
Java deals differently for a cause of null and an unset cause. If the cause is initialized with null subsequent calls to initCause() will fail. If the cause is unset a subsequent call to initCause() works.

This solution introduces a "flag-exception" to indicate that no cause has been set and thus the cause gets only initialized if the cause has been explicitly set by the API user.

To analyze the problem you can have a look at `Throwable.initCause()`: If the cause is unset it's a self-reference to the exception itself and serves as indicator for _cause is unset_. If you call `initCause` with a cause already set it will fail with an `IllegalStateException`.

---

I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
