### PR TITLE
Change MultipleFailuresError to support Throwables

### DIFF
--- a/src/main/java/org/opentest4j/MultipleFailuresError.java
+++ b/src/main/java/org/opentest4j/MultipleFailuresError.java
@@ -22,8 +22,10 @@ import java.util.List;
 
 /**
  * {@link MultipleFailuresError} is an {@link AssertionError} which
- * aggregates multiple {@code AssertionErrors} thrown in a given context
+ * aggregates multiple {@code Throwable} thrown in a given context
  * (i.e., typically within the invocation of a single test).
+ *
+ * This class accepts addition of null Throwables.
  *
  * @author Johannes Link
  * @author Sam Brannen
@@ -34,7 +36,7 @@ public class MultipleFailuresError extends AssertionError {
 
 	private static final long serialVersionUID = 1L;
 
-	private final List<AssertionError> failures = new ArrayList<AssertionError>();
+	private final List<Throwable> failures = new ArrayList<Throwable>();
 
 	private final String heading;
 
@@ -42,7 +44,7 @@ public class MultipleFailuresError extends AssertionError {
 		this.heading = isBlank(heading) ? "Multiple Failures" : heading.trim();
 	}
 
-	public void addFailure(AssertionError failure) {
+	public void addFailure(Throwable failure) {
 		this.failures.add(failure);
 	}
 
@@ -66,7 +68,7 @@ public class MultipleFailuresError extends AssertionError {
 		// @formatter:on
 
 		int lastIndex = failureCount - 1;
-		for (AssertionError failure : this.failures.subList(0, lastIndex)) {
+		for (Throwable failure : this.failures.subList(0, lastIndex)) {
 			builder.append("\t").append(nullSafeMessage(failure)).append(lineSeparator);
 		}
 		builder.append('\t').append(nullSafeMessage(this.failures.get(lastIndex)));
@@ -74,7 +76,7 @@ public class MultipleFailuresError extends AssertionError {
 		return builder.toString();
 	}
 
-	public List<AssertionError> getFailures() {
+	public List<Throwable> getFailures() {
 		return Collections.unmodifiableList(this.failures);
 	}
 
@@ -90,11 +92,13 @@ public class MultipleFailuresError extends AssertionError {
 		return count == 1 ? singular : plural;
 	}
 
-	private static String nullSafeMessage(AssertionError failure) {
+	private static String nullSafeMessage(Throwable failure) {
+		if (failure == null) {
+			return "failure with <null> throwable";
+		}
 		if (isBlank(failure.getMessage())) {
 			return "<no message> in " + failure.getClass().getName();
 		}
 		return failure.getMessage();
 	}
-
 }


### PR DESCRIPTION
As individual failures had to be childs of AssertionError this made
MultipleFailuresError unsuitable for JUnit4 tests using ErrorCollector
which can register multiple failures of type Throwable.

Also adds a null check for throwables in getMessage(). Each added throwable
is -in essence- mapped to an instance created with
org.junit.platform.engine.TestExecutionResult.failed() which is very
clearly documented to accept null values. In that case the message
method would crash.

Resolves: #30, junit-team/junit5#659


---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
