### PR TITLE
Make MultipleFailuresError immutable and accept Throwable

### DIFF
--- a/src/main/java/org/opentest4j/MultipleFailuresError.java
+++ b/src/main/java/org/opentest4j/MultipleFailuresError.java
@@ -34,16 +34,20 @@ public class MultipleFailuresError extends AssertionError {
 
 	private static final long serialVersionUID = 1L;
 
-	private final List<AssertionError> failures = new ArrayList<AssertionError>();
+	private final List<Throwable> failures;
 
 	private final String heading;
 
-	public MultipleFailuresError(String heading) {
+	public MultipleFailuresError(String heading, List<? extends Throwable> failuresList) {
 		this.heading = isBlank(heading) ? "Multiple Failures" : heading.trim();
-	}
 
-	public void addFailure(AssertionError failure) {
-		this.failures.add(failure);
+		this.failures = new ArrayList<Throwable>();
+		for (Throwable failure : failuresList) {
+			if (failure == null) {
+				throw new NullPointerException("failuresList cannot contain null elements.");
+			}
+			this.failures.add(failure);
+		}
 	}
 
 	@Override
@@ -66,7 +70,7 @@ public class MultipleFailuresError extends AssertionError {
 		// @formatter:on
 
 		int lastIndex = failureCount - 1;
-		for (AssertionError failure : this.failures.subList(0, lastIndex)) {
+		for (Throwable failure : this.failures.subList(0, lastIndex)) {
 			builder.append("\t").append(nullSafeMessage(failure)).append(lineSeparator);
 		}
 		builder.append('\t').append(nullSafeMessage(this.failures.get(lastIndex)));
@@ -74,7 +78,7 @@ public class MultipleFailuresError extends AssertionError {
 		return builder.toString();
 	}
 
-	public List<AssertionError> getFailures() {
+	public List<Throwable> getFailures() {
 		return Collections.unmodifiableList(this.failures);
 	}
 
@@ -90,7 +94,7 @@ public class MultipleFailuresError extends AssertionError {
 		return count == 1 ? singular : plural;
 	}
 
-	private static String nullSafeMessage(AssertionError failure) {
+	private static String nullSafeMessage(Throwable failure) {
 		if (isBlank(failure.getMessage())) {
 			return "<no message> in " + failure.getClass().getName();
 		}

--- a/src/test/java/org/opentest4j/MultipleFailuresErrorTests.java
+++ b/src/test/java/org/opentest4j/MultipleFailuresErrorTests.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+
 import org.junit.Test;
 
 /**
@@ -81,9 +83,11 @@ public class MultipleFailuresErrorTests {
 
 	@Test
 	public void mfeWithNullMessageFailures() throws Exception {
-		MultipleFailuresError mfe = new MultipleFailuresError(HEADING);
-		mfe.addFailure(new AssertionError());
-		mfe.addFailure(new AssertionFailedError());
+		ArrayList<Throwable> failures = new ArrayList<Throwable>();
+		failures.add(new AssertionError());
+		failures.add(new AssertionFailedError());
+
+		MultipleFailuresError mfe = new MultipleFailuresError(HEADING, failures);
 
 		assertEquals(
 			String.format("%s %s%n\t%s%n\t%s", HEADING, "(2 failures)", //
@@ -92,8 +96,17 @@ public class MultipleFailuresErrorTests {
 			mfe.getMessage());
 	}
 
+	@Test(expected = NullPointerException.class)
+	public void mfeThrowsNPEForNullFailureElements() {
+		ArrayList<Throwable> failures = new ArrayList<Throwable>();
+		failures.add(new AssertionError());
+		failures.add(null);
+
+		new MultipleFailuresError("", failures);
+	}
+
 	private void assertExceptionWithNoFailures(String inputHeading, String outputHeading) {
-		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading);
+		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading, new ArrayList<Throwable>());
 
 		assertTrue(mfe.getFailures().isEmpty());
 		assertFalse(mfe.hasFailures());
@@ -101,8 +114,10 @@ public class MultipleFailuresErrorTests {
 	}
 
 	private void assertExceptionWithSingleFailure(String inputHeading, String outputHeading) {
-		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading);
-		mfe.addFailure(new AssertionError("failure 1"));
+		ArrayList<Throwable> failures = new ArrayList<Throwable>();
+		failures.add(new AssertionError("failure 1"));
+
+		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading, failures);
 
 		assertEquals(1, mfe.getFailures().size());
 		assertTrue(mfe.hasFailures());
@@ -110,9 +125,11 @@ public class MultipleFailuresErrorTests {
 	}
 
 	private void assertExceptionWithFailures(String inputHeading, String outputHeading) {
-		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading);
-		mfe.addFailure(new AssertionError("failure 1"));
-		mfe.addFailure(new AssertionError("failure 2"));
+		ArrayList<Throwable> failures = new ArrayList<Throwable>();
+		failures.add(new AssertionError("failure 1"));
+		failures.add(new AssertionError("failure 2"));
+
+		MultipleFailuresError mfe = new MultipleFailuresError(inputHeading, failures);
 
 		assertEquals(2, mfe.getFailures().size());
 		assertTrue(mfe.hasFailures());


### PR DESCRIPTION
Make MFE immutable by only accepting failures via a List constructor
parameter.

Move null check for failure elements during construction as this would
fail with an NPE at getMessage().

Also change the type of failures from AssertionError to Throwable so
this class can be used by the Vintage engine to report multiple failures
for JUnit4 tests using ErrorCollector so it can be used to resovle
junit-team/junit5#659.

Resolves: #30, #33
See also: junit-team/junit5#659


---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
