### PR TITLE
Add stable automatic module name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,8 @@ jar {
 			'Specification-Vendor': 'opentest4j.org',
 			'Implementation-Title': project.name,
 			'Implementation-Version': project.version,
-			'Implementation-Vendor': 'opentest4j.org'
+			'Implementation-Vendor': 'opentest4j.org',
+			'Automatic-Module-Name': 'org.opentest4j'
 		)
 	}
 }


### PR DESCRIPTION
## Overview

Add the `Automatic-Module-Name` attribute to the manifest with stable value: `org.opentest4j`

See https://github.com/junit-team/junit5/issues/866 for details.

Closes #36


---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
