### PR TITLE
Include OSGi metadata in published artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ ext {
 }
 
 apply plugin: 'java'
+apply plugin: 'osgi'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven'
@@ -82,6 +83,8 @@ jar {
 			'Implementation-Vendor': 'opentest4j.org',
 			'Automatic-Module-Name': 'org.opentest4j'
 		)
+		license = 'The Apache License, Version 2.0'
+		vendor = 'opentest4j.org'
 	}
 }
 


### PR DESCRIPTION
The 'osgi' Gradle plugin analyzes source files and creates an OSGi
compatible MANIFEST.MF containing "Import-Package" and "Export-Package"
as well as some further "Bundle-*" attributes.
(see also https://docs.gradle.org/current/userguide/osgi_plugin.html)

## Overview

This is required for https://github.com/junit-team/junit5/pull/1353 to the complete transitive dependency chain OSGi compatible. I will provide a manual test case within the JUnit5 issue.

---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
