### PR TITLE
Capture non Serializable inputs to ValueWrapper as transient field

### DIFF
--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -61,6 +61,7 @@ public final class ValueWrapper implements Serializable {
 	private final Class<?> type;
 	private final String stringRepresentation;
 	private final int identityHashCode;
+	private final transient Object ephemeralValue;
 
 	/**
 	 * Reads and stores the supplied value's runtime type, string representation, and
@@ -78,6 +79,7 @@ public final class ValueWrapper implements Serializable {
 		}
 		this.stringRepresentation = stringValue;
 		this.identityHashCode = System.identityHashCode(value);
+		this.ephemeralValue = value;
 	}
 
 	/**
@@ -120,6 +122,14 @@ public final class ValueWrapper implements Serializable {
 	 */
 	public int getIdentityHashCode() {
 		return this.identityHashCode;
+	}
+
+	/**
+	 * Returns the value supplied to {@link #create(Object)} even if the value
+	 * is not {@link Serializable}.
+	 */
+	public Object getEphemeralValue() {
+		return this.ephemeralValue;
 	}
 
 	/**

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -125,8 +125,8 @@ public final class ValueWrapper implements Serializable {
 	}
 
 	/**
-	 * Returns the value supplied to {@link #create(Object)} even if the value
-	 * is not {@link Serializable}.
+	 * Returns the value supplied to {@link #create(Object)}. if {@code ValueWrapper}
+	 * has been been serialized this will return {@code null}
 	 */
 	public Object getEphemeralValue() {
 		return this.ephemeralValue;

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -128,7 +128,9 @@ public final class ValueWrapper implements Serializable {
 	 * Returns the value supplied to {@link #create(Object)}.
 	 *
 	 * <p>if {@code ValueWrapper}
-	 * has been been serialized this will return {@code null}
+	 * has been been serialized this will return {@code null}`
+	 *
+	 * @since 1.2
 	 */
 	public Object getEphemeralValue() {
 		return this.ephemeralValue;

--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -125,7 +125,9 @@ public final class ValueWrapper implements Serializable {
 	}
 
 	/**
-	 * Returns the value supplied to {@link #create(Object)}. if {@code ValueWrapper}
+	 * Returns the value supplied to {@link #create(Object)}.
+	 *
+	 * <p>if {@code ValueWrapper}
 	 * has been been serialized this will return {@code null}
 	 */
 	public Object getEphemeralValue() {

--- a/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
+++ b/src/test/java/org/opentest4j/AssertionFailedErrorTests.java
@@ -158,6 +158,23 @@ public class AssertionFailedErrorTests {
 		assertEquals("bar", error.getActual().getValue());
 	}
 
+	@Test
+	public void ephemeralValueIsOmittedFromSerialization() throws Exception {
+		class NonSerializable {
+			public final String guid = "8675309";
+		}
+
+		AssertionFailedError error = serializeAndDeserialize(
+			new AssertionFailedError("a message", new NonSerializable(), new NonSerializable()));
+		assertEquals("a message", error.getMessage());
+		assertTrue(error.isExpectedDefined());
+		assertNull(error.getExpected().getValue());
+		assertNull(error.getExpected().getEphemeralValue());
+		assertTrue(error.isActualDefined());
+		assertNull(error.getActual().getValue());
+		assertNull(error.getActual().getEphemeralValue());
+	}
+
 	private Object deserializeClasspathResource(String name) throws Exception {
 		InputStream inputStream = getClass().getResourceAsStream(name);
 		try {

--- a/src/test/java/org/opentest4j/ValueWrapperTests.java
+++ b/src/test/java/org/opentest4j/ValueWrapperTests.java
@@ -19,6 +19,7 @@ package org.opentest4j;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
@@ -43,6 +44,7 @@ public class ValueWrapperTests {
 		assertEquals("null", wrapper.getStringRepresentation());
 		assertEquals(0, wrapper.getIdentityHashCode());
 		assertEquals("null", wrapper.toString());
+		assertNull(wrapper.getEphemeralValue());
 	}
 
 	@Test
@@ -55,6 +57,8 @@ public class ValueWrapperTests {
 		assertNotEquals(0, wrapper.getIdentityHashCode());
 		assertTrue(wrapper.toString().startsWith("1.2 (java.lang.Double@"));
 		assertTrue(wrapper.toString().endsWith(")"));
+		assertEquals(1.2D, wrapper.getEphemeralValue());
+		assertSame(wrapper.getValue(), wrapper.getEphemeralValue());
 	}
 
 	@Test
@@ -74,6 +78,7 @@ public class ValueWrapperTests {
 		assertNull(wrapper.getValue());
 		assertEquals("someString", wrapper.getStringRepresentation());
 		assertNotEquals(0, wrapper.getIdentityHashCode());
+		assertEquals(value, wrapper.getEphemeralValue());
 
 		String toString = wrapper.toString();
 		assertTrue(toString, toString.startsWith("someString (" + NonSerializable.class.getName() + "@"));
@@ -96,6 +101,7 @@ public class ValueWrapperTests {
 
 		assertEquals(BrokenToString.class, wrapper.getType());
 		assertEquals(value, wrapper.getValue());
+		assertEquals(value, wrapper.getEphemeralValue());
 		String representation = wrapper.getStringRepresentation();
 		assertTrue(representation, representation.contains(RuntimeException.class.getName()));
 		assertTrue(representation, representation.contains("toStringFailure"));


### PR DESCRIPTION
## Overview

- Caputre non Serializable inputs to ValueWrapper as transient field

There seems to have been some discussion about this in the past: https://github.com/ota4j-team/opentest4j/issues/2 https://github.com/ota4j-team/opentest4j/issues/49 and https://github.com/ota4j-team/opentest4j/pull/50

This constraint can be hard to work with if somebody is trying to use those values but has no control over what a user inputs into their assertions.

**A concrete example:**
JUnit 5 has an extension model which allows for processing of test cases and failure scenarios, such as [TestExcecutionExceptionHandler](https://junit.org/junit5/docs/5.3.0/api/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.html).

During the execution of those extensions we are still in the same runtime. Having access to provided test inputs would be helpful for processing real objects - as compared to analyzing only their string representation

**A proposed solution:**
Exposing the same instance as a transient field will keep compatibility for Serialized requirements but allow access in test frameworks.

Given the ephemeral object is the same instance it would have a very minimal impact on `ValueWrapper` as `identityHashCode()`, `toString()`, and `getType()` would remain unchanged.

---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
