### PR TITLE
Add the option to provide a custom stringRepresentation to ValueWrapper

### DIFF
--- a/src/main/java/org/opentest4j/ValueWrapper.java
+++ b/src/main/java/org/opentest4j/ValueWrapper.java
@@ -57,6 +57,23 @@ public final class ValueWrapper implements Serializable {
 		return (value == null ? nullValueWrapper : new ValueWrapper(value));
 	}
 
+	/**
+	 * Factory for creating a new {@code ValueWrapper} for the supplied {@code value}.
+	 *
+	 * <p>If the supplied {@code value} is {@code null}, this method will return a
+	 * cached {@code ValueWrapper} suitable for all null values.
+	 *
+	 * @param value the value to wrap; may be {@code null}
+	 * @param stringRepresentation a custom rendering of the value, use when you don't
+	 *                             want to rely on {@link Object#toString()} will fallback
+	 *                             to default behavior if null
+	 * @return a wrapper for the supplied value
+	 * @since 1.2.0
+	 */
+	public static ValueWrapper create(Object value, String stringRepresentation) {
+		return (value == null ? nullValueWrapper : new ValueWrapper(value, stringRepresentation));
+	}
+
 	private final Serializable value;
 	private final Class<?> type;
 	private final String stringRepresentation;
@@ -66,18 +83,24 @@ public final class ValueWrapper implements Serializable {
 	 * Reads and stores the supplied value's runtime type, string representation, and
 	 * identity hash code.
 	 */
-	private ValueWrapper(Object value) {
+	private ValueWrapper(Object value, String stringRepresentation) {
 		this.value = value instanceof Serializable ? (Serializable) value : null;
 		this.type = value != null ? value.getClass() : null;
-		String stringValue;
+		this.stringRepresentation = stringRepresentation == null ? safeValueToString(value) : stringRepresentation;
+		this.identityHashCode = System.identityHashCode(value);
+	}
+
+	private ValueWrapper(Object value) {
+		this(value, safeValueToString(value));
+	}
+
+	private static String safeValueToString(Object value) {
 		try {
-			stringValue = String.valueOf(value);
+			return String.valueOf(value);
 		}
 		catch (Exception e) {
-			stringValue = "<Exception in toString(): " + e + ">";
+			return "<Exception in toString(): " + e + ">";
 		}
-		this.stringRepresentation = stringValue;
-		this.identityHashCode = System.identityHashCode(value);
 	}
 
 	/**

--- a/src/test/java/org/opentest4j/ValueWrapperTests.java
+++ b/src/test/java/org/opentest4j/ValueWrapperTests.java
@@ -58,6 +58,30 @@ public class ValueWrapperTests {
 	}
 
 	@Test
+	public void acceptsCustomStringRepresentation() {
+		ValueWrapper wrapper = ValueWrapper.create(1.2d, "1,20");
+
+		assertEquals(Double.class, wrapper.getType());
+		assertEquals(1.2d, wrapper.getValue());
+		assertEquals("1,20", wrapper.getStringRepresentation());
+		assertNotEquals(0, wrapper.getIdentityHashCode());
+		assertTrue(wrapper.toString().startsWith("1,20 (java.lang.Double@"));
+		assertTrue(wrapper.toString().endsWith(")"));
+	}
+
+	@Test
+	public void nullForCustomStringRepresentationFallsBackToDefaultToString() {
+		ValueWrapper wrapper = ValueWrapper.create(1.2d, null);
+
+		assertEquals(Double.class, wrapper.getType());
+		assertEquals(1.2d, wrapper.getValue());
+		assertEquals("1.2", wrapper.getStringRepresentation());
+		assertNotEquals(0, wrapper.getIdentityHashCode());
+		assertTrue(wrapper.toString().startsWith("1.2 (java.lang.Double@"));
+		assertTrue(wrapper.toString().endsWith(")"));
+	}
+
+	@Test
 	public void wrapsNonSerializableValue() {
 		class NonSerializable {
 


### PR DESCRIPTION
The motivation is that a framework may have special support to render
a value in a more meaningful way than the default Object.toString(),
e.g., the Spock Framework uses custom renderings in
AssertionFailedErrors.

---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
