### PR TITLE
Include Java module descriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - ./gradlew --version # Display Gradle, Groovy, JVM and other versions
 
 jdk:
-  - oraclejdk8
+  - openjdk11
 
 stages:
   - test

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import java.text.SimpleDateFormat
+import java.util.spi.ToolProvider
 
 plugins {
 	id 'java'
@@ -8,7 +9,6 @@ plugins {
 	id 'maven'
 	id 'signing'
 	id 'com.diffplug.gradle.spotless' version '3.23.0'
-	id 'ru.vyarus.animalsniffer' version '1.5.0'
 	id 'net.nemerosa.versioning' version '2.8.2'
 	id 'org.ajoberstar.github-pages' version '1.7.2'
 }
@@ -27,19 +27,23 @@ repositories {
 }
 
 compileJava {
-	// please also update accordingly the animalsniffer config down below when changing the compatibility settings
-	sourceCompatibility = 1.6
-	targetCompatibility = 1.6
+	getOptions().getCompilerArgs().addAll('--release', '6')
 }
 
-compileTestJava {
-	sourceCompatibility = 1.6
-	targetCompatibility = 1.6
+task compileModule() {
+	dependsOn(compileJava)
+	doLast {
+		ToolProvider.findFirst('javac').orElseThrow().run(System.out, System.err,
+			'--release', '9',
+			'-d', file(buildDir).toString(),
+			'--module-source-path', file('src/module/java').toString(),
+			'--patch-module', 'org.opentest4j=' + file('src/main/java').toString(),
+			'--module', 'org.opentest4j')
+	}
 }
 
 dependencies {
 	testCompile("junit:junit:${junit4Version}")
-	signature('org.codehaus.mojo.signature:java16:1.1@signature')
 }
 
 test {
@@ -69,11 +73,15 @@ jar {
 			'Specification-Vendor': 'opentest4j.org',
 			'Implementation-Title': project.name,
 			'Implementation-Version': project.version,
-			'Implementation-Vendor': 'opentest4j.org',
-			'Automatic-Module-Name': 'org.opentest4j'
+			'Implementation-Vendor': 'opentest4j.org'
 		)
 		license = 'The Apache License, Version 2.0'
 		vendor = 'opentest4j.org'
+	}
+
+	dependsOn(compileModule)
+	from('build/org.opentest4j') {
+		include 'module-info.class'
 	}
 }
 
@@ -82,7 +90,7 @@ javadoc {
 	options.author = true
 	options.header = 'Open Test Alliance for the JVM'
 	options.addStringOption('Xdoclint:html,syntax,reference', '-quiet')
-	options.links 'https://docs.oracle.com/javase/8/docs/api/'
+	options.links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ task compileModule(type: JavaCompile) {
 	options.compilerArgs = [
 			'--release', '9',
 			'--module-source-path', moduleSrcDir.toString(),
-			'--patch-module', 'org.opentest4j=' + sourceSets.main.allJava.srcDirs.join(':'),
+			'--patch-module', "$moduleName=${sourceSets.main.allJava.srcDirs.join(':')}",
 			'--module', moduleName
 	]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,25 +21,28 @@ ext {
 }
 
 description = 'Open Test Alliance for the JVM'
+def moduleName = 'org.opentest4j'
 
 repositories {
 	mavenCentral()
 }
 
 compileJava {
-	getOptions().getCompilerArgs().addAll('--release', '6')
+	options.compilerArgs = ['--release', '6']
 }
 
-task compileModule() {
-	dependsOn(compileJava)
-	doLast {
-		ToolProvider.findFirst('javac').orElseThrow().run(System.out, System.err,
+task compileModule(type: JavaCompile) {
+	def moduleSrcDir = file('src/module/java')
+	source(moduleSrcDir)
+	destinationDir = file("$buildDir/classes/java/modules")
+	classpath = compileJava.classpath
+	inputs.property("moduleName", moduleName)
+	options.compilerArgs = [
 			'--release', '9',
-			'-d', file(buildDir).toString(),
-			'--module-source-path', file('src/module/java').toString(),
-			'--patch-module', 'org.opentest4j=' + file('src/main/java').toString(),
-			'--module', 'org.opentest4j')
-	}
+			'--module-source-path', moduleSrcDir.toString(),
+			'--patch-module', 'org.opentest4j=' + sourceSets.main.allJava.srcDirs.join(':'),
+			'--module', moduleName
+	]
 }
 
 dependencies {
@@ -55,8 +58,8 @@ test {
 def normalizeVersion = { versionLiteral ->
 	try {
 		(versionLiteral =~ /(\d+)\.(\d+)\.(\d+).*/)[0][1..3].join('.')
-	} catch(x) {
-		throw new GradleException("Version '$versionLiteral' does not match version pattern, e.g. 1.0.0-QUALIFIER")
+	} catch (e) {
+		throw new GradleException("Version '$versionLiteral' does not match version pattern, e.g. 1.0.0-QUALIFIER", e)
 	}
 }
 
@@ -78,10 +81,8 @@ jar {
 		license = 'The Apache License, Version 2.0'
 		vendor = 'opentest4j.org'
 	}
-
-	dependsOn(compileModule)
-	from('build/org.opentest4j') {
-		include 'module-info.class'
+	from(files("${compileModule.destinationDir}/$moduleName").builtBy(compileModule)) {
+		include('module-info.class')
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import java.text.SimpleDateFormat
-import java.util.spi.ToolProvider
 
 plugins {
 	id 'java'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 rootProject.name = 'opentest4j'
 
 // Require Java 11
-int javaVersion = Integer.valueOf(JavaVersion.current().getMajorVersion())
-if (javaVersion != 11) {
+if (!JavaVersion.current().java11) {
 	throw new GradleException('The OpenTest4J build requires Java 11. ' +
-			"Currently executing with Java ${javaVersion}.")
+			"Currently executing with Java ${JavaVersion.current()}.")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'opentest4j'
+
+// Require Java 11
+int javaVersion = Integer.valueOf(JavaVersion.current().getMajorVersion())
+if (javaVersion != 11) {
+	throw new GradleException('The OpenTest4J build requires Java 11. ' +
+			"Currently executing with Java ${javaVersion}.")
+}

--- a/src/module/README.md
+++ b/src/module/README.md
@@ -1,0 +1,7 @@
+# Module `org.opentest4j`
+
+## `javac` command
+
+```
+javac -d src/main/module --release 9 --module-source-path src/main/module --patch-module=org.opentest4j=src/main/java --module org.opentest4j
+```

--- a/src/module/README.md
+++ b/src/module/README.md
@@ -1,7 +1,0 @@
-# Module `org.opentest4j`
-
-## `javac` command
-
-```
-javac -d src/main/module --release 9 --module-source-path src/main/module --patch-module=org.opentest4j=src/main/java --module org.opentest4j
-```

--- a/src/module/java/org.opentest4j/module-info.java
+++ b/src/module/java/org.opentest4j/module-info.java
@@ -1,0 +1,3 @@
+module org.opentest4j {
+	exports org.opentest4j;
+}


### PR DESCRIPTION
## Overview

Supersedes and closes #51 by including Java module descriptor at the root of the generated JAR file. 

This PR upgrades the JDK required to build the project to 11.

---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
