### PR TITLE
add copyright and license to jar

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,13 @@
+Copyright 2015-2018 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,11 @@ jar {
 	from(files("${compileModule.destinationDir}/$moduleName").builtBy(compileModule)) {
 		include('module-info.class')
 	}
+
+	from(".") {
+		include("LICENSE")
+		include("COPYRIGHT")
+	}
 }
 
 javadoc {


### PR DESCRIPTION
### Add license and copyright information to Jar.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar File. Therefore it would be great to have the license and copyright information included in the Jar File. 

---
I hereby agree to the terms of the Open Test Alliance Contributor License Agreement.
