### PR TITLE
Bump Gradle Wrapper from 8.5-rc-3 to 8.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7207f771dac48bfe19d5990c8f1e7e5f3d5e8b2b98e09ad9a4c484af537f86b2
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-rc-3-bin.zip
+distributionSha256Sum=9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.5-rc-3 to 8.5.

Release notes of Gradle 8.5 can be found here:
https://docs.gradle.org/8.5/release-notes.html